### PR TITLE
Skip tests all in one place

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,4 +97,7 @@ subprojects {
     test {
         systemProperty 'bc.test.data.home', bcTestDataHome
     }
+
+    // skip tests, this is just a dependency and we're not changing it
+    test.enabled=false
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,6 +7,3 @@ dependencies {
 sourceCompatibility = 1.5
 targetCompatibility = 1.5
 version = '1.50.0.0'
-
-// skip tests
-build.dependsOn.remove("check")

--- a/pg/build.gradle
+++ b/pg/build.gradle
@@ -9,6 +9,3 @@ dependencies {
 sourceCompatibility = 1.5
 targetCompatibility = 1.5
 version = '1.50.0.0'
-
-// skip tests
-build.dependsOn.remove("check")

--- a/pkix/build.gradle
+++ b/pkix/build.gradle
@@ -9,6 +9,3 @@ dependencies {
 sourceCompatibility = 1.5
 targetCompatibility = 1.5
 version = '1.50.0.0'
-
-// skip tests
-build.dependsOn.remove("check")

--- a/prov/build.gradle
+++ b/prov/build.gradle
@@ -8,6 +8,3 @@ dependencies {
 sourceCompatibility = 1.5
 targetCompatibility = 1.5
 version = '1.50.0.0'
-
-// skip tests
-build.dependsOn.remove("check")


### PR DESCRIPTION
`test.enabled=false` is a more reliable way of excluding the bouncycastle tests (which are slow - over 5 minutes on my machine).  I've been using `./gradlew clean cleanTest check` in the root of open-keychain to verify this; in the old configuration, it runs the BC tests even though they should be disabled..

Ideally we would put this higher up in the gradle build, in the openkeychain root gradle.build but I haven't yet figured out how to do that
